### PR TITLE
v0.3.1

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+    "root": true,
+    "env": {
+        "es2021": true,
+        "node": true
+    },
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": [
+            "error",
+            "tab"
+        ],
+        "linebreak-style": [
+            "error",
+            "windows"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,51 @@
+name: 非预期行为和漏洞
+description: 提交一个非预期行为和漏洞报告。
+#title:
+labels:
+  - bug
+  - question
+assignees:
+  - BTMuli
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢您的提交，至少填写下方带红色星花标记的部分。
+  - type: textarea
+    id: question
+    attributes:
+      label: 问题描述
+      description: 在此详细描述你遇到的非预期行为或漏洞。
+      placeholder: 在此输入 Markdown 文本。
+      #value:
+    validations:
+      required: true
+  - type: textarea
+    id: operation
+    attributes:
+      label: 复现流程
+      description: 告诉我们如何操作才有可能重现你的问题，以便我们定位和解决。
+      placeholder: 在此输入 Markdown 文本。
+      #value:
+    validations:
+      required: true
+  - type: textarea
+    id: git-log
+    attributes:
+      label: 当前提交
+      description: 将命令 `git log -1` 输出粘贴在此处。
+      render: Text
+      placeholder: 在粘贴命令输出，将被转化为代码块。
+      #value:
+    validations:
+      required: true
+  - type: textarea
+    id: git-status
+    attributes:
+      label: 代码状态
+      description: 将命令 `git status` 输出粘贴在此处。
+      render: Text
+      placeholder: 在粘贴命令输出，将被转化为代码块。
+      #value:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,32 @@
+name: 新功能
+description: 提交一个新功能请求。
+#title: 你的标题
+labels:
+  - enhancement
+  - question
+assignees:
+  - BTMuli
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢您的提交，至少填写下方带红色星花标记的部分。
+  - type: textarea
+    id: question
+    attributes:
+      label: 问题描述
+      description: 在此详细描述你想新增的功能。
+      placeholder: 在此输入 Markdown 文本。
+      #value:
+    validations:
+      required: true
+  - type: textarea
+    id: git-log
+    attributes:
+      label: 当前提交
+      description: 将命令 `git log -1` 的输出粘贴在此处。
+      render: Text
+      placeholder: 在粘贴命令输出，将被转化为代码块。
+      #value:
+    validations:
+      required: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
-#      - run: npm test
+  #      - run: npm test
 
   publish-gpr:
     needs: build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 Date: 2022-09-29
-Update: 2022-10-07
+Update: 2022-10-10
 Author: 目棃
 Description: 说明文档
 ---
@@ -24,7 +24,7 @@ Description: 说明文档
 主 CLI 采用的是 `muc` 命令，其运行如下：
 
 ```text
-> muc
+> muc -h
 Usage: muc [options] [command]
 
 A Node Cli for Personal Use by BTMUli.
@@ -64,21 +64,34 @@ Commands:
 对应的是上面的 `mmd` 命令：
 
 ```text
-> muc mmd
+> muc mmd -h
 Usage: muc mmd [options] [command]
 
 A SubCommand within MuCli for Markdown
 
 Options:
-  -sv             output the version number
-  -h, --help      display help for command
+  -sv               output the version number
+  -h, --help        display help for command
 
 Commands:
-  new [options]   create a markdown file
-  help [command]  display help for command
+  new [options]     create a markdown file
+  typora [options]  using local Typora - config is needed
+  help [command]    display help for command
 ```
 
-目前仅有 `muc mmd new -n [mdFileName]` 的创建新 Markdown 文件并配置其 Front-matter 的功能。
+目前的功能有两个：新建 Markdown 文件与调用 [`Typora`](https://typoraio.cn/) 打开文件。
+
+```text
+> muc mmd typora -h
+Usage: muc mmd typora [options]
+
+using local Typora - config is needed
+
+Options:
+  -n [name]   open [name] with Typora (default: "")
+  -p, --path  get local typora path
+  -h, --help  display help for command
+```
 
 默认内容如下（以 `muc mmd new -n README` 为例）
 
@@ -94,12 +107,12 @@ Description: 说明文档
 `2022-10-07 15:34:07`
 ```
 
-### Cli-SubCommand
+### SubCli-SubCommand
 
 对应的是上面的 `ncm` 命令：
 
 ```text
-> muc ncm
+> muc ncm -h
 Usage: muc ncm [options] [command]
 
 A SubCommand within MuCli for SubCommand

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ---
 Date: 2022-09-29
-Update: 2022-09-30
+Update: 2022-10-07
 Author: 目棃
 Description: 说明文档
 ---
 
-> 本文档由 MuCli 自动生成
+> 本文档 [`Front-matter`](https://github.com/BTMuli/MuCli#README#FrontMatter) 由 [`MuCli`](https://github.com/BTMuli/MuCli) 自动生成
 
 ![](https://img.shields.io/github/license/BTMuli/MuCli?style=for-the-badge)![](https://img.shields.io/github/workflow/status/btmuli/MuCli/MuCli%20Workflow/master?style=for-the-badge)![](https://img.shields.io/github/package-json/v/btmuli/mucli/master?style=for-the-badge)![](https://img.shields.io/github/last-commit/btmuli/mucli/master?style=for-the-badge)
 
@@ -15,11 +15,148 @@ Description: 说明文档
 
 > 若你写的 Workflow 发布到不同平台，则需保证`package.json`没有 `publishConfig` 之类的配置，其会覆盖你在 `workflow.yml`中写的路径。
 
+---
+
+## 命令说明
+
+本 CLI 采用加载子命令的形式运行，可以通过修改 [`config.yml`](./config_default/config.yml) 对应 command 的 `enable` 属性来选择是否加载。
+
+主 CLI 采用的是 `muc` 命令，其运行如下：
+
+```text
+> muc
+Usage: muc [options] [command]
+
+A Node Cli for Personal Use by BTMUli.
+
+Options:
+  -v, --version   output the version number
+  -h, --help      display help for command
+
+Commands:
+  mmd [options]   A SubCommand within MuCli for Markdown
+  ncm [options]   A SubCommand within MuCli for SubCommand
+  help [command]  display help for command
+```
+
+如上，除了 Commander 默认的 `help` 之外，目前有两个子命令，`mmd` 跟 `ncm`。
+
+### 查看版本
+
+主 CLI 采用 `-v` 或 `--version` 查看版本，如下：
+
+```text
+> muc -v
+0.3.0
+```
+
+子命令则通过 `-sv` 即 `subversion` 来查看，如下:
+
+```text
+> muc mmd -sv
+0.2.0
+> muc ncm -sv
+0.0.2
+```
+
+### SubCli-Markdown
+
+对应的是上面的 `mmd` 命令：
+
+```text
+> muc mmd
+Usage: muc mmd [options] [command]
+
+A SubCommand within MuCli for Markdown
+
+Options:
+  -sv             output the version number
+  -h, --help      display help for command
+
+Commands:
+  new [options]   create a markdown file
+  help [command]  display help for command
+```
+
+目前仅有 `muc mmd new -n [mdFileName]` 的创建新 Markdown 文件并配置其 Front-matter 的功能。
+
+默认内容如下（以 `muc mmd new -n README` 为例）
+
+```markdown
+---
+Date: 2022-10-07
+Update: 2022-10-07
+Author: 目棃
+Description: 说明文档
+---
+
+> 本文档 [`Front-matter`](https://github.com/BTMuli/Mucli#FrontMatter) 由 [MuCli](https://github.com/BTMuli/Mucli) 自动生成于
+`2022-10-07 15:34:07`
+```
+
+### Cli-SubCommand
+
+对应的是上面的 `ncm` 命令：
+
+```text
+> muc ncm
+Usage: muc ncm [options] [command]
+
+A SubCommand within MuCli for SubCommand
+
+Options:
+  -sv             output the version number
+  -h, --help      display help for command
+
+Commands:
+  new [options]
+  help [command]  display help for command
+```
+
+用于个人新建一个子命令，即 `Just for dev`。
+
+---
+
+## FrontMatter
+
+`Frontmatter` 即前言，用来说明书目的总结跟内容。
+
+但是在 Markdown 中， Front-matter 指的是 `.md` 文件最开始的那部分，如本文，其 `Frontmatter` 为:
+
+```markdown
+---
+Date: 2022-09-29
+Update: 2022-10-07
+Author: 目棃
+Description: 说明文档
+---
+```
+
+是以 `yaml` 格式在文件开头增加的元数据。
+
+---
+
 ## 提交规范
 
 本项目 Commit 采用 [Angular 团队提交规范](https://zjdoc-gitguide.readthedocs.io/zh_CN/latest/message/angular-commit.html)。
 
 通过 Webstorm 上的插件 [Git Commit Template](https://plugins.jetbrains.com/plugin/9861-git-commit-template) 予以辅助。
+
+其提交格式如下：
+
+```text
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+每次提交可以包含页眉 `header` 、正文 `body` 和页脚 `footer` ，每次提交必须包含页眉内容
+
+每次提交的信息不超过100个字符
+
+---
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Description: 说明文档
 
 > 本文档 [`Front-matter`](https://github.com/BTMuli/MuCli#README#FrontMatter) 由 [`MuCli`](https://github.com/BTMuli/MuCli) 自动生成
 
-![](https://img.shields.io/github/license/BTMuli/MuCli?style=for-the-badge)![](https://img.shields.io/github/workflow/status/btmuli/MuCli/MuCli%20Workflow/master?style=for-the-badge)![](https://img.shields.io/github/package-json/v/btmuli/mucli/master?style=for-the-badge)![](https://img.shields.io/github/last-commit/btmuli/mucli/master?style=for-the-badge)
+![](https://img.shields.io/github/license/BTMuli/MuCli?style=for-the-badge)![](https://img.shields.io/github/workflow/status/btmuli/MuCli/MuCli%20Workflow?style=for-the-badge)![](https://img.shields.io/github/package-json/v/btmuli/mucli?style=for-the-badge)![](https://img.shields.io/github/last-commit/btmuli/mucli?style=for-the-badge)
 
 ## 前言
 

--- a/cli/SubCommand.js
+++ b/cli/SubCommand.js
@@ -6,7 +6,7 @@ const subCommand = new Command();
 // Base info
 subCommand
     .name('ncm')
-    .description('create a sub command')
+    .description('A SubCommand within MuCli for SubCommand')
     .version('0.0.2', '-sv')
 
 // Command for create a new command(for dev)

--- a/cli/SubCommand.js
+++ b/cli/SubCommand.js
@@ -7,10 +7,11 @@ const subCommand = new Command();
 subCommand
     .name('ncm')
     .description('create a sub command')
-    .version('0.0.1', '-sv')
+    .version('0.0.2', '-sv')
 
 // Command for create a new command(for dev)
 subCommand
+    .command('new')
     .option('-n [command]', 'new sub [command]')
     .action(args => {
         let muc = new SubCommand()

--- a/cli/SubCommand.js
+++ b/cli/SubCommand.js
@@ -1,21 +1,21 @@
-import {Command} from "commander";
-import SubCommand from "../utils/SubCommand.js";
+import {Command} from 'commander';
+import SubCommand from '../utils/SubCommand.js';
 
 const subCommand = new Command();
 
 // Base info
 subCommand
-    .name('ncm')
-    .description('A SubCommand within MuCli for SubCommand')
-    .version('0.0.2', '-sv')
+	.name('ncm')
+	.description('A SubCommand within MuCli for SubCommand')
+	.version('0.0.2', '-sv');
 
 // Command for create a new command(for dev)
 subCommand
-    .command('new')
-    .option('-n [command]', 'new sub [command]')
-    .action(args => {
-        let muc = new SubCommand()
-        muc.createNew(args.n)
-    })
+	.command('new')
+	.option('-n [command]', 'new sub [command]')
+	.action(args => {
+		let muc = new SubCommand();
+		muc.createNew(args.n);
+	});
 
-export default subCommand
+export default subCommand;

--- a/cli/index.js
+++ b/cli/index.js
@@ -13,7 +13,10 @@ MuCli
     .version('0.3.0', '-v, --version')
     .description("A Node Cli for Personal Use by BTMUli.");
 
-// Commands add func
+/**
+ * 检验权限然后添加命令
+ * @param cmd 命令
+ */
 function setCommand(...cmd) {
     var config = new Config()
     cmd.forEach(value => {

--- a/cli/index.js
+++ b/cli/index.js
@@ -5,7 +5,6 @@ import Config from "../config/index.js";
 // Personal SubCommand
 import markdown from "./markdown.js";
 import subCommand from "./SubCommand.js";
-import bangumi from "./bangumi.js";
 
 const MuCli = new Command()
 
@@ -28,6 +27,6 @@ function setCommand(...cmd) {
 }
 
 // Commands add
-setCommand(markdown, subCommand, bangumi)
+setCommand(markdown, subCommand)
 
 export default MuCli;

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,32 +1,32 @@
 // Default Commander
-import {Command} from "commander";
+import {Command} from 'commander';
 // Config file
-import Config from "../config/index.js";
+import Config from '../config/index.js';
 // Personal SubCommand
-import markdown from "./markdown.js";
-import subCommand from "./SubCommand.js";
+import markdown from './markdown.js';
+import subCommand from './SubCommand.js';
 
-const MuCli = new Command()
+const MuCli = new Command();
 
 // Base info
 MuCli
-    .name('muc')
-    .version('0.3.0', '-v, --version')
-    .description("A Node Cli for Personal Use by BTMUli.");
+	.name('muc')
+	.version('0.3.0', '-v, --version')
+	.description('A Node Cli for Personal Use by BTMUli.');
 
 /**
  * 检验权限然后添加命令
  * @param cmd 命令
  */
 function setCommand(...cmd) {
-    var config = new Config()
-    cmd.forEach(value => {
-        if (config.doConfig(value))
-            MuCli.addCommand(value)
-    })
+	var config = new Config();
+	cmd.forEach(value => {
+		if (config.doConfig(value))
+			MuCli.addCommand(value);
+	});
 }
 
 // Commands add
-setCommand(markdown, subCommand)
+setCommand(markdown, subCommand);
 
 export default MuCli;

--- a/cli/index.js
+++ b/cli/index.js
@@ -20,7 +20,7 @@ MuCli
 function setCommand(...cmd) {
     var config = new Config()
     cmd.forEach(value => {
-        if(config.doConfig(value))
+        if (config.doConfig(value))
             MuCli.addCommand(value)
     })
 }

--- a/cli/index.js
+++ b/cli/index.js
@@ -11,7 +11,7 @@ const MuCli = new Command();
 // Base info
 MuCli
 	.name('muc')
-	.version('0.3.0', '-v, --version')
+	.version('0.3.1', '-v, --version')
 	.description('A Node Cli for Personal Use by BTMUli.');
 
 /**

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,15 +1,17 @@
 // Default Commander
 import {Command} from "commander";
+// Config file
+import Config from "../config/index.js";
 // Personal SubCommand
 import markdown from "./markdown.js";
 import subCommand from "./SubCommand.js";
-import Config from "../config/index.js";
+import bangumi from "./bangumi.js";
 
 const MuCli = new Command()
 
 // Base info
 MuCli
-    .name('MuCli')
+    .name('muc')
     .version('0.3.0', '-v, --version')
     .description("A Node Cli for Personal Use by BTMUli.");
 
@@ -26,6 +28,6 @@ function setCommand(...cmd) {
 }
 
 // Commands add
-setCommand(markdown, subCommand)
+setCommand(markdown, subCommand, bangumi)
 
 export default MuCli;

--- a/cli/markdown.js
+++ b/cli/markdown.js
@@ -24,17 +24,18 @@ markdown
     .command('typora')
     // Using Typora
     .option('-n [name]', 'open [name] with Typora', '')
-    .description('open file with Typora - config is needed')
-    .action(args => {
-        let md = new Markdown()
-        md.openTypora(args.n)
-    })
+    .description('open file with Typora')
     // Get Typora Info
     .option('-p, --path','get local typora path')
     .description('get local typora path')
-    .action(() => {
+    .action(args => {
         let md = new Markdown()
-        console.log(md.getConfigTypora().path)
+        if(args.path){
+            console.log(md.getConfigTypora().path)
+        } else if (args.n) {
+            md.openTypora(args.n)
+        }
     })
+    .description('using local Typora - config is needed')
 
 export default markdown;

--- a/cli/markdown.js
+++ b/cli/markdown.js
@@ -6,7 +6,7 @@ const markdown = new Command();
 // Base info
 markdown
     .name('mmd')
-    .description('A Sub SubCommand within MuCli for Markdown.')
+    .description('A SubCommand within MuCli for Markdown')
     .version('0.2.0', '-sv')
 
 // SubCommand for create markdown new file

--- a/cli/markdown.js
+++ b/cli/markdown.js
@@ -1,41 +1,41 @@
-import {Command} from "commander";
-import Markdown from "../utils/markdown.js";
+import {Command} from 'commander';
+import Markdown from '../utils/markdown.js';
 
 const markdown = new Command();
 
 // Base info
 markdown
-    .name('mmd')
-    .description('A SubCommand within MuCli for Markdown')
-    .version('0.3.0', '-sv')
+	.name('mmd')
+	.description('A SubCommand within MuCli for Markdown')
+	.version('0.3.0', '-sv');
 
 // SubCommand for create markdown new file
 markdown
-    .command('new')
-    .option('-n [name]', 'new markdown file [name]', 'README')
-    .description('create a markdown file')
-    .action(args => {
-        let md = new Markdown()
-        md.createNew(args.n)
-    })
+	.command('new')
+	.option('-n [name]', 'new markdown file [name]', 'README')
+	.description('create a markdown file')
+	.action(args => {
+		let md = new Markdown();
+		md.createNew(args.n);
+	});
 
 // SubCommand for open file with Typora - config is needed
 markdown
-    .command('typora')
-    // Using Typora
-    .option('-n [name]', 'open [name] with Typora', '')
-    .description('open file with Typora')
-    // Get Typora Info
-    .option('-p, --path','get local typora path')
-    .description('get local typora path')
-    .action(args => {
-        let md = new Markdown()
-        if(args.path){
-            console.log(md.getConfigTypora().path)
-        } else if (args.n) {
-            md.openTypora(args.n)
-        }
-    })
-    .description('using local Typora - config is needed')
+	.command('typora')
+// Using Typora
+	.option('-n [name]', 'open [name] with Typora', '')
+	.description('open file with Typora')
+// Get Typora Info
+	.option('-p, --path','get local typora path')
+	.description('get local typora path')
+	.action(args => {
+		let md = new Markdown();
+		if(args.path){
+			console.log(md.getConfigTypora().path);
+		} else if (args.n) {
+			md.openTypora(args.n);
+		}
+	})
+	.description('using local Typora - config is needed');
 
 export default markdown;

--- a/cli/markdown.js
+++ b/cli/markdown.js
@@ -7,12 +7,12 @@ const markdown = new Command();
 markdown
     .name('mmd')
     .description('A Sub SubCommand within MuCli for Markdown.')
-    .version('0.1.5', '-sv')
+    .version('0.2.0', '-sv')
 
 // SubCommand for create markdown new file
 markdown
     .command('new')
-    .option('-n [name]', 'new markdown file [name]','README')
+    .option('-n [name]', 'new markdown file [name]', 'README')
     .description('create a markdown file')
     .action(args => {
         let md = new Markdown()

--- a/cli/markdown.js
+++ b/cli/markdown.js
@@ -7,7 +7,7 @@ const markdown = new Command();
 markdown
     .name('mmd')
     .description('A SubCommand within MuCli for Markdown')
-    .version('0.2.0', '-sv')
+    .version('0.3.0', '-sv')
 
 // SubCommand for create markdown new file
 markdown
@@ -17,6 +17,24 @@ markdown
     .action(args => {
         let md = new Markdown()
         md.createNew(args.n)
+    })
+
+// SubCommand for open file with Typora - config is needed
+markdown
+    .command('typora')
+    // Using Typora
+    .option('-n [name]', 'open [name] with Typora', '')
+    .description('open file with Typora - config is needed')
+    .action(args => {
+        let md = new Markdown()
+        md.openTypora(args.n)
+    })
+    // Get Typora Info
+    .option('-p, --path','get local typora path')
+    .description('get local typora path')
+    .action(() => {
+        let md = new Markdown()
+        console.log(md.getConfigTypora().path)
     })
 
 export default markdown;

--- a/config.js
+++ b/config.js
@@ -1,0 +1,12 @@
+import path from "path";
+import {fileURLToPath} from "url";
+
+class MucConfig {
+    static rootPath = path.dirname(fileURLToPath(import.meta.url));
+
+    static getPath() {
+        return this.rootPath;
+    }
+}
+
+export default MucConfig

--- a/config.js
+++ b/config.js
@@ -1,12 +1,12 @@
-import path from "path";
-import {fileURLToPath} from "url";
+import path from 'path';
+import {fileURLToPath} from 'node:url';
 
 class MucConfig {
-    static rootPath = path.dirname(fileURLToPath(import.meta.url));
+	static rootPath = path.dirname(fileURLToPath(import.meta.url));
 
-    static getPath() {
-        return this.rootPath;
-    }
+	static getPath() {
+		return this.rootPath;
+	}
 }
 
-export default MucConfig
+export default MucConfig;

--- a/config/SubCommand.js
+++ b/config/SubCommand.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-class SubCommandModel{
+class SubCommandModel {
     // 项目根目录
     rootDir = path.resolve() + '\\'
 
@@ -12,12 +12,12 @@ class SubCommandModel{
     }
 
     // 字符串替换
-    transCommand(name){
+    transCommand(name) {
         return name.slice(0, 1).toUpperCase() + name.slice(1).toLowerCase()
     }
 
     // 构造几个文件
-    getFilesPath(){
+    getFilesPath() {
         var fileName = this.name + '.js'
         var cliPath = this.rootDir + 'cli\\' + fileName
         var configPath = this.rootDir + 'config\\' + fileName
@@ -27,7 +27,7 @@ class SubCommandModel{
 
     // 根据类型返回文件内容
     getModel(key) {
-        switch (key){
+        switch (key) {
             case 'cliPath':
                 return this.getCliModel()
             case 'configPath':
@@ -52,7 +52,7 @@ class SubCommandModel{
             "    .name('" + this.command + "')\n" +
             "    .description('" + this.description + "')\n" +
             "    .version('0.0.1', '-sv')\n\n" +
-            "export default "+ this.name +";\n"
+            "export default " + this.name + ";\n"
     }
 
     // Config 目录文件，负责 Model 构建
@@ -67,7 +67,8 @@ class SubCommandModel{
     getUtilsModel() {
         var fileName = this.name + '.js'
         var clsName = this.transCommand(this.name)
-        return "import inquirer from \"inquirer\";\n" +
+        return "//此文件由 MuCli 自动生成\n" +
+            "import inquirer from \"inquirer\";\n" +
             "import " + clsName + "Model from \"../config/" + fileName + "\";\n" +
             "import MucFile from \"./file.js\";\n\n" +
             "class " + clsName + "{\n\n}\n\n" +

--- a/config/SubCommand.js
+++ b/config/SubCommand.js
@@ -1,79 +1,79 @@
-import MucConfig from "../config.js";
+import MucConfig from '../config.js';
 
 class SubCommandModel {
-    // 项目根目录
-    rootDir = MucConfig.getPath()
+	// 项目根目录
+	rootDir = MucConfig.getPath();
 
-    // 初始化命令
-    constructor(name, command, desc) {
-        this.name = name
-        this.command = command
-        this.description = desc
-    }
+	// 初始化命令
+	constructor(name, command, desc) {
+		this.name = name;
+		this.command = command;
+		this.description = desc;
+	}
 
-    // 字符串替换
-    transCommand(name) {
-        return name.slice(0, 1).toUpperCase() + name.slice(1).toLowerCase()
-    }
+	// 字符串替换
+	transCommand(name) {
+		return name.slice(0, 1).toUpperCase() + name.slice(1).toLowerCase();
+	}
 
-    // 构造几个文件
-    getFilesPath() {
-        var fileName = this.name + '.js'
-        var cliPath = this.rootDir + '\\cli\\' + fileName
-        var configPath = this.rootDir + '\\config\\' + fileName
-        var utilsPath = this.rootDir + '\\utils\\' + fileName
-        return {cliPath, configPath, utilsPath}
-    }
+	// 构造几个文件
+	getFilesPath() {
+		var fileName = this.name + '.js';
+		var cliPath = this.rootDir + '\\cli\\' + fileName;
+		var configPath = this.rootDir + '\\config\\' + fileName;
+		var utilsPath = this.rootDir + '\\utils\\' + fileName;
+		return {cliPath, configPath, utilsPath};
+	}
 
-    // 根据类型返回文件内容
-    getModel(key) {
-        switch (key) {
-            case 'cliPath':
-                return this.getCliModel()
-            case 'configPath':
-                return this.getConfigModel()
-            case 'utilsPath':
-                return this.getUtilsModel()
-            default:
-                return false
-        }
-    }
+	// 根据类型返回文件内容
+	getModel(key) {
+		switch (key) {
+		case 'cliPath':
+			return this.getCliModel();
+		case 'configPath':
+			return this.getConfigModel();
+		case 'utilsPath':
+			return this.getUtilsModel();
+		default:
+			return false;
+		}
+	}
 
-    // Cli 目录文件，负责 command 对应命令
-    getCliModel() {
-        var fileName = this.name + '.js'
-        var clsName = this.transCommand(this.name)
-        return "//此文件由 MuCli 自动生成\n" +
-            "import {Command} from \"commander\";\n" +
-            "import " + clsName + " from \"../utils/" + fileName + "\";\n\n" +
-            "const " + this.name + "= new Command();\n\n" +
-            "// Base info\n" +
-            this.name + "\n" +
-            "    .name('" + this.command + "')\n" +
-            "    .description('" + this.description + "')\n" +
-            "    .version('0.0.1', '-sv')\n\n" +
-            "export default " + this.name + ";\n"
-    }
+	// Cli 目录文件，负责 command 对应命令
+	getCliModel() {
+		var fileName = this.name + '.js';
+		var clsName = this.transCommand(this.name);
+		return '//此文件由 MuCli 自动生成\n' +
+            'import {Command} from "commander";\n' +
+            'import ' + clsName + ' from "../utils/' + fileName + '";\n\n' +
+            'const ' + this.name + '= new Command();\n\n' +
+            '// Base info\n' +
+            this.name + '\n' +
+            '    .name(\'' + this.command + '\')\n' +
+            '    .description(\'' + this.description + '\')\n' +
+            '    .version(\'0.0.1\', \'-sv\')\n\n' +
+            'export default ' + this.name + ';\n';
+	}
 
-    // Config 目录文件，负责 Model 构建
-    getConfigModel() {
-        var clsName = this.transCommand(this.name)
-        return "//此文件由 MuCli 自动生成\n" +
-            "class " + clsName + "Model {\n\n}\n\n" +
-            "export default " + clsName + "Model;"
-    }
+	// Config 目录文件，负责 Model 构建
+	getConfigModel() {
+		var clsName = this.transCommand(this.name);
+		return '//此文件由 MuCli 自动生成\n' +
+            'class ' + clsName + 'Model {\n\n}\n\n' +
+            'export default ' + clsName + 'Model;';
+	}
 
-    // Utils 目录文件，负责交互
-    getUtilsModel() {
-        var fileName = this.name + '.js'
-        var clsName = this.transCommand(this.name)
-        return "//此文件由 MuCli 自动生成\n" +
-            "import inquirer from \"inquirer\";\n" +
-            "import " + clsName + "Model from \"../config/" + fileName + "\";\n" +
-            "import MucFile from \"./file.js\";\n\n" +
-            "class " + clsName + "{\n\n}\n\n" +
-            "export default " + clsName + ";"
-    }
+	// Utils 目录文件，负责交互
+	getUtilsModel() {
+		var fileName = this.name + '.js';
+		var clsName = this.transCommand(this.name);
+		return '//此文件由 MuCli 自动生成\n' +
+            'import inquirer from "inquirer";\n' +
+            'import ' + clsName + 'Model from "../config/' + fileName + '";\n' +
+            'import MucFile from "./file.js";\n\n' +
+            'class ' + clsName + '{\n\n}\n\n' +
+            'export default ' + clsName + ';';
+	}
 }
 
-export default SubCommandModel
+export default SubCommandModel;

--- a/config/SubCommand.js
+++ b/config/SubCommand.js
@@ -1,8 +1,8 @@
-import path from "node:path";
+import MucConfig from "../config.js";
 
 class SubCommandModel {
     // 项目根目录
-    rootDir = path.resolve() + '\\'
+    rootDir = MucConfig.getPath()
 
     // 初始化命令
     constructor(name, command, desc) {
@@ -19,9 +19,9 @@ class SubCommandModel {
     // 构造几个文件
     getFilesPath() {
         var fileName = this.name + '.js'
-        var cliPath = this.rootDir + 'cli\\' + fileName
-        var configPath = this.rootDir + 'config\\' + fileName
-        var utilsPath = this.rootDir + 'utils\\' + fileName
+        var cliPath = this.rootDir + '\\cli\\' + fileName
+        var configPath = this.rootDir + '\\config\\' + fileName
+        var utilsPath = this.rootDir + '\\utils\\' + fileName
         return {cliPath, configPath, utilsPath}
     }
 

--- a/config/index.js
+++ b/config/index.js
@@ -1,50 +1,50 @@
-import MucYaml from "../utils/yaml.js";
-import MucConfig from "../config.js";
+import MucYaml from '../utils/yaml.js';
+import MucConfig from '../config.js';
 
 class Config {
-    constructor() {
-        this.configPath = MucConfig.getPath() + '\\config_default\\config.yml'
-        this.mucYaml = new MucYaml()
-    }
+	constructor() {
+		this.configPath = MucConfig.getPath() + '\\config_default\\config.yml';
+		this.mucYaml = new MucYaml();
+	}
 
-    /**
+	/**
      * 读取配置文件
      * @return {JSON}
      */
-    readConfig() {
-        return this.mucYaml.yamlRead(this.configPath)
-    }
+	readConfig() {
+		return this.mucYaml.yamlRead(this.configPath);
+	}
 
-    /**
+	/**
      * 读取子配置
      * @param args 可变参数，所获取位置
      * @return {*|JSON}
      */
-    readDetailConfig(...args) {
-        var configRead = this.readConfig()
-        configRead = this.mucYaml.yamlDetailRead(configRead, args)
-        return configRead
-    }
+	readDetailConfig(...args) {
+		var configRead = this.readConfig();
+		configRead = this.mucYaml.yamlDetailRead(configRead, args);
+		return configRead;
+	}
 
-    /**
+	/**
      * 加载检验
      * @param cmd 命令
      * @return {boolean} 是否开启
      */
-    doConfig(cmd) {
-        var cmdConfig = this.readDetailConfig('Commands', cmd.name())
-        return cmdConfig['enable'] === true;
-    }
+	doConfig(cmd) {
+		var cmdConfig = this.readDetailConfig('Commands', cmd.name());
+		return cmdConfig['enable'] === true;
+	}
 
-    /**
+	/**
      * 修改 yml todo 待检验
      * @param val  修改后的值
      * @param key  修改项
      * @param args 可选参数，位置
      */
-    transConfig(val, key, ...args) {
-        this.mucYaml.yamlChange(this.configPath, args, key, val)
-    }
+	transConfig(val, key, ...args) {
+		this.mucYaml.yamlChange(this.configPath, args, key, val);
+	}
 }
 
-export default Config
+export default Config;

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,6 @@
 import MucYaml from "../utils/yaml.js";
 
-class Config{
+class Config {
     constructor() {
         this.configPath = './config_default/config.yml'
         this.mucYaml = new MucYaml()
@@ -10,7 +10,7 @@ class Config{
      * 读取配置文件
      * @return {JSON}
      */
-    readConfig(){
+    readConfig() {
         return this.mucYaml.yamlRead(this.configPath)
     }
 
@@ -19,7 +19,7 @@ class Config{
      * @param args 可变参数，所获取位置
      * @return {*|JSON}
      */
-    readDetailConfig(...args){
+    readDetailConfig(...args) {
         var configRead = this.readConfig()
         configRead = this.mucYaml.yamlDetailRead(configRead, args)
         return configRead
@@ -30,7 +30,7 @@ class Config{
      * @param cmd 命令
      * @return {boolean} 是否开启
      */
-    doConfig(cmd){
+    doConfig(cmd) {
         var cmdConfig = this.readDetailConfig('Commands', cmd.name())
         return cmdConfig['enable'] === true;
     }
@@ -41,7 +41,7 @@ class Config{
      * @param key  修改项
      * @param args 可选参数，位置
      */
-    transConfig(val, key, ...args){
+    transConfig(val, key, ...args) {
         this.mucYaml.yamlChange(this.configPath, args, key, val)
     }
 }

--- a/config/index.js
+++ b/config/index.js
@@ -6,23 +6,43 @@ class Config{
         this.mucYaml = new MucYaml()
     }
 
+    /**
+     * 读取配置文件
+     * @return {JSON}
+     */
     readConfig(){
         return this.mucYaml.yamlRead(this.configPath)
     }
 
+    /**
+     * 读取子配置
+     * @param args 可变参数，所获取位置
+     * @return {*|JSON}
+     */
     readDetailConfig(...args){
         var configRead = this.readConfig()
         configRead = this.mucYaml.yamlDetailRead(configRead, args)
         return configRead
     }
-    // 按需加载
+
+    /**
+     * 加载检验
+     * @param cmd 命令
+     * @return {boolean} 是否开启
+     */
     doConfig(cmd){
         var cmdConfig = this.readDetailConfig('Commands', cmd.name())
         return cmdConfig['enable'] === true;
     }
-    // 修改 yml todo 待检验
-    transConfig(val, cmd, ...args){
-        this.mucYaml.yamlChange(this.configPath, args, cmd, val)
+
+    /**
+     * 修改 yml todo 待检验
+     * @param val  修改后的值
+     * @param key  修改项
+     * @param args 可选参数，位置
+     */
+    transConfig(val, key, ...args){
+        this.mucYaml.yamlChange(this.configPath, args, key, val)
     }
 }
 

--- a/config/index.js
+++ b/config/index.js
@@ -1,8 +1,9 @@
 import MucYaml from "../utils/yaml.js";
+import MucConfig from "../config.js";
 
 class Config {
     constructor() {
-        this.configPath = './config_default/config.yml'
+        this.configPath = MucConfig.getPath() + '\\config_default\\config.yml'
         this.mucYaml = new MucYaml()
     }
 

--- a/config/markdown.js
+++ b/config/markdown.js
@@ -2,7 +2,7 @@ import {format} from 'silly-datetime';
 
 class MarkdownModel {
     sign = "---"
-    quote = "> 本文档由 [MuCli](https://github.com/BTMuli/Mucli) 自动生成于"
+    quote = "> 本文档 [`Front-matter`](https://github.com/BTMuli/Mucli#FrontMatter) 由 [MuCli](https://github.com/BTMuli/Mucli) 自动生成于"
 
     // 构造函数，相当于 py 中的  __init__()
     constructor(author, desc) {

--- a/config/markdown.js
+++ b/config/markdown.js
@@ -1,7 +1,6 @@
 import {format} from 'silly-datetime';
 
 class MarkdownModel {
-    // 默认配置， todo 通过 yml 配置文件读取/全局设置
     sign = "---"
     quote = "> 本文档由 [MuCli](https://github.com/BTMuli/Mucli) 自动生成于"
 

--- a/config/markdown.js
+++ b/config/markdown.js
@@ -11,6 +11,10 @@ class MarkdownModel {
         this.description = desc
     }
 
+    /**
+     * 获取默认写入内容
+     * @return {string}
+     */
     getModel() {
         var dateNow = format(new Date(), 'YYYY-MM-DD');
         return this.sign + "\n" +

--- a/config/markdown.js
+++ b/config/markdown.js
@@ -1,30 +1,30 @@
 import {format} from 'silly-datetime';
 
 class MarkdownModel {
-    sign = "---"
-    quote = "> 本文档 [`Front-matter`](https://github.com/BTMuli/Mucli#FrontMatter) 由 [MuCli](https://github.com/BTMuli/Mucli) 自动生成于"
+	sign = '---';
+	quote = '> 本文档 [`Front-matter`](https://github.com/BTMuli/Mucli#FrontMatter) 由 [MuCli](https://github.com/BTMuli/Mucli) 自动生成于';
 
-    // 构造函数，相当于 py 中的  __init__()
-    constructor(author, desc) {
-        this.author = author
-        this.description = desc
-    }
+	// 构造函数，相当于 py 中的  __init__()
+	constructor(author, desc) {
+		this.author = author;
+		this.description = desc;
+	}
 
-    /**
+	/**
      * 获取默认写入内容
      * @return {string}
      */
-    getModel() {
-        var dateNow = format(new Date(), 'YYYY-MM-DD');
-        return this.sign + "\n" +
-            "Date: " + dateNow + "\n" +
-            "Update: " + dateNow + "\n" +
-            "Author: " + this.author + "\n" +
-            "Description: " + this.description + "\n" +
-            this.sign + "\n" + "\n" +
-            this.quote + "\n" +
-            "`" + format(new Date(), 'YYYY-MM-DD HH:mm:ss') + "`";
-    }
+	getModel() {
+		var dateNow = format(new Date(), 'YYYY-MM-DD');
+		return this.sign + '\n' +
+            'Date: ' + dateNow + '\n' +
+            'Update: ' + dateNow + '\n' +
+            'Author: ' + this.author + '\n' +
+            'Description: ' + this.description + '\n' +
+            this.sign + '\n' + '\n' +
+            this.quote + '\n' +
+            '`' + format(new Date(), 'YYYY-MM-DD HH:mm:ss') + '`';
+	}
 }
 
-export default MarkdownModel
+export default MarkdownModel;

--- a/config_default/config.yml
+++ b/config_default/config.yml
@@ -5,9 +5,12 @@ Commands:
     enable: true
     name: markdown
     default:
-      author: 目棃
+      author: '目棃'
       filename: 'README'
       description: '说明文档'
+    typora:
+      enable: true
+      path: 'E:\\SoftWares\\Typora\\Typora.exe'
   # SubCommand
   ncm:
     enable: true

--- a/config_default/config.yml
+++ b/config_default/config.yml
@@ -4,7 +4,10 @@ Commands:
   mmd:
     enable: true
     name: markdown
-    author: 目棃
+    default:
+      author: 目棃
+      filename: 'README'
+      description: '说明文档'
   # SubCommand
   ncm:
     enable: true

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import MuCli from "./cli/index.js";
+import MuCli from './cli/index.js';
 
 const cmd = process.argv;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/node": "^18.7.21",
         "commander": "^9.4.0",
+        "eslint": "^8.25.0",
         "inquirer": "^9.1.2",
         "silly-datetime": "^0.1.2",
         "yamljs": "^0.3.0"
@@ -19,10 +20,128 @@
         "muc": "index.js"
       }
     },
+    "node_modules/@eslint/eslintrc": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.4.0",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.7.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
       "integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA=="
+    },
+    "node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "5.0.0",
@@ -68,6 +187,14 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -111,6 +238,17 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -132,6 +270,14 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/chalk": {
@@ -191,6 +337,22 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "node_modules/commander": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
@@ -204,12 +366,68 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
     "node_modules/defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
       "dependencies": {
         "clone": "^1.0.2"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/eastasianwidth": {
@@ -233,6 +451,218 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "dependencies": {
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.4.0",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.15.0",
+        "globby": "^11.1.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+      "dependencies": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -244,6 +674,55 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/figures": {
@@ -260,6 +739,60 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -283,6 +816,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/iconv-lite": {
@@ -314,6 +915,37 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -354,6 +986,25 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -363,6 +1014,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -376,10 +1035,77 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/log-symbols": {
       "version": "5.1.0",
@@ -394,6 +1120,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -415,10 +1161,20 @@
         "node": "*"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -440,6 +1196,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ora": {
@@ -472,6 +1244,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -479,6 +1298,68 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
@@ -491,6 +1372,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/restore-cursor": {
@@ -508,12 +1408,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -548,6 +1493,25 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -557,6 +1521,14 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/silly-datetime/-/silly-datetime-0.1.2.tgz",
       "integrity": "sha512-q8hnO91rRvQsYTYaZCJc6UpljzfdmWD3bNljDLKGVBT2ukj7snE+ENkVVkXfo529ABLEBeN6PHoEaT1ONEq81w=="
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -601,6 +1573,33 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -617,10 +1616,32 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "1.4.0",
@@ -631,6 +1652,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -644,6 +1673,28 @@
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -679,13 +1730,105 @@
         "json2yaml": "bin/json2yaml",
         "yaml2json": "bin/yaml2json"
       }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
+    "@eslint/eslintrc": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.4.0",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@types/node": {
       "version": "18.7.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
       "integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA=="
+    },
+    "acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "requires": {}
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
     },
     "ansi-escapes": {
       "version": "5.0.0",
@@ -712,6 +1855,11 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -742,6 +1890,14 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -750,6 +1906,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "chalk": {
       "version": "5.0.1",
@@ -784,6 +1945,19 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
     },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "commander": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
@@ -794,12 +1968,51 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
       "requires": {
         "clone": "^1.0.2"
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "requires": {
+        "esutils": "^2.0.2"
       }
     },
     "eastasianwidth": {
@@ -817,6 +2030,153 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
     },
+    "eslint": {
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "requires": {
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.4.0",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.15.0",
+        "globby": "^11.1.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
+    },
+    "espree": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+      "requires": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -827,6 +2187,51 @@
         "tmp": "^0.0.33"
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
     "figures": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
@@ -835,6 +2240,45 @@
         "escape-string-regexp": "^5.0.0",
         "is-unicode-supported": "^1.2.0"
       }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -854,6 +2298,52 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "globals": {
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "requires": {
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        }
+      }
+    },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -866,6 +2356,25 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -903,20 +2412,95 @@
         "wrap-ansi": "^8.0.1"
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
     "is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-unicode-supported": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q=="
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        }
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "log-symbols": {
       "version": "5.1.0",
@@ -925,6 +2509,20 @@
       "requires": {
         "chalk": "^5.0.0",
         "is-unicode-supported": "^1.1.0"
+      }
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mimic-fn": {
@@ -940,10 +2538,20 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "once": {
       "version": "1.4.0",
@@ -959,6 +2567,19 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
     },
     "ora": {
@@ -982,10 +2603,69 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -997,6 +2677,16 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
     "restore-cursor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
@@ -1006,10 +2696,31 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "rxjs": {
       "version": "7.5.7",
@@ -1029,6 +2740,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -1038,6 +2762,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/silly-datetime/-/silly-datetime-0.1.2.tgz",
       "integrity": "sha512-q8hnO91rRvQsYTYaZCJc6UpljzfdmWD3bNljDLKGVBT2ukj7snE+ENkVVkXfo529ABLEBeN6PHoEaT1ONEq81w=="
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1070,6 +2799,24 @@
         "ansi-regex": "^6.0.1"
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -1083,15 +2830,39 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
     "type-fest": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1105,6 +2876,19 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wrap-ansi": {
       "version": "8.0.1",
@@ -1129,6 +2913,11 @@
         "argparse": "^1.0.7",
         "glob": "^7.0.5"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@btmuli/mucli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@btmuli/mucli",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.7.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btmuli/mucli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "个人用的 Node Cli",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "个人用的 Node Cli",
   "type": "module",
   "main": "index.js",
+  "scripts": {
+    "lint-all": "eslint cli/* config/* utils/* config.js index.js",
+    "lintfix": "eslint cli/* config/* utils/* config.js index.js --fix"
+  },
   "bin": {
     "muc": "./index.js"
   },
@@ -27,6 +31,7 @@
     "commander": "^9.4.0",
     "inquirer": "^9.1.2",
     "silly-datetime": "^0.1.2",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "eslint": "^8.25.0"
   }
 }

--- a/utils/SubCommand.js
+++ b/utils/SubCommand.js
@@ -1,28 +1,28 @@
-import inquirer from "inquirer";
-import MucFile from "./file.js";
-import SubCommandModel from "../config/SubCommand.js";
+import inquirer from 'inquirer';
+import MucFile from './file.js';
+import SubCommandModel from '../config/SubCommand.js';
 
 
 class SubCommand {
-    createNew(name) {
-        var mucFile = new MucFile()
-        inquirer.prompt([
-            {type: 'input', message: '请输入 SubCommand 名称', name: 'name', default: name || 'test'},
-            {type: 'input', message: '请输入 SubCommand 命令', name: 'command', default: 'test'},
-            {
-                type: 'input',
-                message: '请输入 SubCommand 简介',
-                name: 'desc',
-                default: 'A SubCommand within MuCli for Test'
-            }
-        ]).then(async answers => {
-            var subC = new SubCommandModel(answers.name, answers.command, answers.desc)
-            var paths = subC.getFilesPath()
-            for (var p in paths) {
-                await mucFile.fileRewriteCheck(paths[p], subC.getModel(p), inquirer)
-            }
-        })
-    }
+	createNew(name) {
+		var mucFile = new MucFile();
+		inquirer.prompt([
+			{type: 'input', message: '请输入 SubCommand 名称', name: 'name', default: name || 'test'},
+			{type: 'input', message: '请输入 SubCommand 命令', name: 'command', default: 'test'},
+			{
+				type: 'input',
+				message: '请输入 SubCommand 简介',
+				name: 'desc',
+				default: 'A SubCommand within MuCli for Test'
+			}
+		]).then(async answers => {
+			var subC = new SubCommandModel(answers.name, answers.command, answers.desc);
+			var paths = subC.getFilesPath();
+			for (var p in paths) {
+				await mucFile.fileRewriteCheck(paths[p], subC.getModel(p), inquirer);
+			}
+		});
+	}
 }
 
-export default SubCommand
+export default SubCommand;

--- a/utils/SubCommand.js
+++ b/utils/SubCommand.js
@@ -4,12 +4,17 @@ import SubCommandModel from "../config/SubCommand.js";
 
 
 class SubCommand {
-    createNew(name){
+    createNew(name) {
         var mucFile = new MucFile()
         inquirer.prompt([
             {type: 'input', message: '请输入 SubCommand 名称', name: 'name', default: name || 'test'},
             {type: 'input', message: '请输入 SubCommand 命令', name: 'command', default: 'test'},
-            {type: 'input', message: '请输入 SubCommand 简介', name: 'desc', default: 'A Sub SubCommand within MuCli for Test'}
+            {
+                type: 'input',
+                message: '请输入 SubCommand 简介',
+                name: 'desc',
+                default: 'A SubCommand within MuCli for Test'
+            }
         ]).then(async answers => {
             var subC = new SubCommandModel(answers.name, answers.command, answers.desc)
             var paths = subC.getFilesPath()

--- a/utils/file.js
+++ b/utils/file.js
@@ -1,13 +1,13 @@
 import fs from "node:fs";
 import util from "node:util";
 
-class MucFile{
+class MucFile {
     /**
      * 文件创建
      * @param path 文件路径
      * @param data 文件内容
      */
-    create(path, data){
+    create(path, data) {
         fs.writeFile(path, data, error => {
             if (error) {
                 console.log("创建失败" + error)
@@ -22,9 +22,9 @@ class MucFile{
      * @param path 文件路径
      * @param data 文件内容
      */
-    change(path, data){
-        fs.writeFile(path, data, error =>{
-            if (error){
+    change(path, data) {
+        fs.writeFile(path, data, error => {
+            if (error) {
                 console.log("文件修改失败！")
                 console.log(error)
             } else {

--- a/utils/file.js
+++ b/utils/file.js
@@ -2,6 +2,11 @@ import fs from "node:fs";
 import util from "node:util";
 
 class MucFile{
+    /**
+     * 文件创建
+     * @param path 文件路径
+     * @param data 文件内容
+     */
     create(path, data){
         fs.writeFile(path, data, error => {
             if (error) {
@@ -12,6 +17,11 @@ class MucFile{
         })
     }
 
+    /**
+     * 文件修改
+     * @param path 文件路径
+     * @param data 文件内容
+     */
     change(path, data){
         fs.writeFile(path, data, error =>{
             if (error){
@@ -23,6 +33,11 @@ class MucFile{
         })
     }
 
+    /**
+     * 文件存在检验
+     * @param name 文件名称暨路径
+     * @return {Promise<boolean>} 文件是否存在
+     */
     async fileExistCheck(name) {
         try {
             let stat = await util.promisify(fs.stat)(name);
@@ -32,6 +47,13 @@ class MucFile{
         }
     }
 
+    /**
+     * 文件覆盖确认
+     * @param path 文件路径
+     * @param data 文件写入数据
+     * @param inq  交互类
+     * @return {Promise<void>} 执行结果
+     */
     async fileRewriteCheck(path, data, inq) {
         if (await this.fileExistCheck(path) === true) {
             inq.prompt([{

--- a/utils/file.js
+++ b/utils/file.js
@@ -1,75 +1,75 @@
-import fs from "node:fs";
-import util from "node:util";
+import fs from 'node:fs';
+import util from 'node:util';
 
 class MucFile {
-    /**
+	/**
      * 文件创建
      * @param path 文件路径
      * @param data 文件内容
      */
-    create(path, data) {
-        fs.writeFile(path, data, error => {
-            if (error) {
-                console.log("创建失败" + error)
-            } else {
-                console.info("\n文件创建成功！\n" + data)
-            }
-        })
-    }
+	create(path, data) {
+		fs.writeFile(path, data, error => {
+			if (error) {
+				console.log('创建失败' + error);
+			} else {
+				console.info('\n文件创建成功！\n' + data);
+			}
+		});
+	}
 
-    /**
+	/**
      * 文件修改
      * @param path 文件路径
      * @param data 文件内容
      */
-    change(path, data) {
-        fs.writeFile(path, data, error => {
-            if (error) {
-                console.log("文件修改失败！")
-                console.log(error)
-            } else {
-                console.log("文件修改成功！")
-            }
-        })
-    }
+	change(path, data) {
+		fs.writeFile(path, data, error => {
+			if (error) {
+				console.log('文件修改失败！');
+				console.log(error);
+			} else {
+				console.log('文件修改成功！');
+			}
+		});
+	}
 
-    /**
+	/**
      * 文件存在检验
      * @param name 文件名称暨路径
      * @return {Promise<boolean>} 文件是否存在
      */
-    async fileExistCheck(name) {
-        try {
-            let stat = await util.promisify(fs.stat)(name);
-            return stat.isFile() === true
-        } catch (err) {
-            return false
-        }
-    }
+	async fileExistCheck(name) {
+		try {
+			let stat = await util.promisify(fs.stat)(name);
+			return stat.isFile() === true;
+		} catch (err) {
+			return false;
+		}
+	}
 
-    /**
+	/**
      * 文件覆盖确认
      * @param path 文件路径
      * @param data 文件写入数据
      * @param inq  交互类
      * @return {Promise<void>} 执行结果
      */
-    async fileRewriteCheck(path, data, inq) {
-        if (await this.fileExistCheck(path) === true) {
-            inq.prompt([{
-                type: 'confirm',
-                message: '文件\"' + path + '\"已存在，是否覆盖？',
-                name: 'choice',
-                default: false
-            }]).then(rc => {
-                if (rc.choice === true) {
-                    this.create(path, data)
-                }
-            })
-        } else {
-            this.create(path, data)
-        }
-    }
+	async fileRewriteCheck(path, data, inq) {
+		if (await this.fileExistCheck(path) === true) {
+			inq.prompt([{
+				type: 'confirm',
+				message: '文件"' + path + '"已存在，是否覆盖？',
+				name: 'choice',
+				default: false
+			}]).then(rc => {
+				if (rc.choice === true) {
+					this.create(path, data);
+				}
+			});
+		} else {
+			this.create(path, data);
+		}
+	}
 }
 
-export default MucFile
+export default MucFile;

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -3,6 +3,10 @@ import MarkdownModel from "../config/markdown.js";
 import MucFile from "./file.js";
 
 class Markdown {
+    /**
+     * 创建新文件
+     * @param name 文件名称
+     */
     createNew(name) {
         var mucFile = new MucFile()
         inquirer.prompt([
@@ -12,7 +16,7 @@ class Markdown {
         ]).then(async answers => {
             var mdModel = new MarkdownModel(answers.author, answers.desc)
             var mdPath = answers.title + '.md'
-            await mucFile.fileRewriteCheck(mdPath, mdModel.getModel())
+            await mucFile.fileRewriteCheck(mdPath, mdModel.getModel(), inquirer)
         })
     }
 }

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -1,78 +1,78 @@
 // Node JS
-import inquirer from "inquirer";
+import inquirer from 'inquirer';
 import {resolve} from 'node:path';
-import {execFile} from "child_process";
+import {execFile} from 'node:child_process';
 // MuCli JS
-import MarkdownModel from "../config/markdown.js";
-import MucFile from "./file.js";
-import Config from "../config/index.js";
+import MarkdownModel from '../config/markdown.js';
+import MucFile from './file.js';
+import Config from '../config/index.js';
 
-var markdownConfig = new Config().readDetailConfig('Commands', 'mmd')
+var markdownConfig = new Config().readDetailConfig('Commands', 'mmd');
 
 class Markdown {
-    /**
+	/**
      * 初始化构建各种设置
      */
-    constructor() {
-        this.configAll = markdownConfig
-        this.authorDefault = markdownConfig.default.author
-        this.fileDefault = markdownConfig.default.filename
-        this.descDefault = markdownConfig.default.description
-        this.typora = markdownConfig.typora
-        if(this.typora.enable){
-            this.typoraPath = this.typora.path
-        }
-    }
+	constructor() {
+		this.configAll = markdownConfig;
+		this.authorDefault = markdownConfig.default.author;
+		this.fileDefault = markdownConfig.default.filename;
+		this.descDefault = markdownConfig.default.description;
+		this.typora = markdownConfig.typora;
+		if(this.typora.enable){
+			this.typoraPath = this.typora.path;
+		}
+	}
 
-    /*
+	/*
      * 获取各种配置
      */
-    getConfigAll() {
-        return this.configAll
-    }
+	getConfigAll() {
+		return this.configAll;
+	}
 
-    getConfigTypora() {
-        return this.typora
-    }
+	getConfigTypora() {
+		return this.typora;
+	}
 
-    /**
+	/**
      * 创建新文件
      * @param name 文件名称
      */
-    createNew(name) {
-        var mucFile = new MucFile()
-        inquirer.prompt([
-            {type: 'input', message: '请输入文件名称', name: 'title', default: name || this.fileDefault},
-            {type: 'input', message: '请输入作者', name: 'author', default: this.authorDefault},
-            {
-                type: 'input',
-                message: '请输入描述',
-                name: 'desc',
-                default: name === this.fileDefault ? this.descDefault : name
-            }
-        ]).then(async answers => {
-            var mdModel = new MarkdownModel(answers.author, answers.desc)
-            var mdPath = answers.title + '.md'
-            await mucFile.fileRewriteCheck(mdPath, mdModel.getModel(), inquirer)
-        })
-    }
+	createNew(name) {
+		var mucFile = new MucFile();
+		inquirer.prompt([
+			{type: 'input', message: '请输入文件名称', name: 'title', default: name || this.fileDefault},
+			{type: 'input', message: '请输入作者', name: 'author', default: this.authorDefault},
+			{
+				type: 'input',
+				message: '请输入描述',
+				name: 'desc',
+				default: name === this.fileDefault ? this.descDefault : name
+			}
+		]).then(async answers => {
+			var mdModel = new MarkdownModel(answers.author, answers.desc);
+			var mdPath = answers.title + '.md';
+			await mucFile.fileRewriteCheck(mdPath, mdModel.getModel(), inquirer);
+		});
+	}
 
-    /**
+	/**
      * 调用 Typora 打开文件
      */
-    openTypora(){
-        if (this.typoraPath){
-            var filePath = resolve() + "\\" + name
-            execFile(this.typoraPath, [filePath], function(err, data) {
-                if (err) {
-                    throw err;
-                }
-                console.log(data.toString());
-            });
-        } else {
-            console.log("Typora 模块未加载！")
-        }
-    }
+	openTypora(name){
+		if (this.typoraPath){
+			var filePath = resolve() + '\\' + name;
+			execFile(this.typoraPath, [filePath], function(err, data) {
+				if (err) {
+					throw err;
+				}
+				console.log(data.toString());
+			});
+		} else {
+			console.log('Typora 模块未加载！');
+		}
+	}
 }
 
 export default Markdown;

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -1,4 +1,8 @@
+// Node JS
 import inquirer from "inquirer";
+import {resolve} from 'node:path';
+import {execFile} from "child_process";
+// MuCli JS
 import MarkdownModel from "../config/markdown.js";
 import MucFile from "./file.js";
 import Config from "../config/index.js";
@@ -6,10 +10,29 @@ import Config from "../config/index.js";
 var markdownConfig = new Config().readDetailConfig('Commands', 'mmd')
 
 class Markdown {
+    /**
+     * 初始化构建各种设置
+     */
     constructor() {
+        this.configAll = markdownConfig
         this.authorDefault = markdownConfig.default.author
         this.fileDefault = markdownConfig.default.filename
         this.descDefault = markdownConfig.default.description
+        this.typora = markdownConfig.typora
+        if(this.typora.enable){
+            this.typoraPath = this.typora.path
+        }
+    }
+
+    /*
+     * 获取各种配置
+     */
+    getConfigAll() {
+        return this.configAll
+    }
+
+    getConfigTypora() {
+        return this.typora
     }
 
     /**
@@ -32,6 +55,23 @@ class Markdown {
             var mdPath = answers.title + '.md'
             await mucFile.fileRewriteCheck(mdPath, mdModel.getModel(), inquirer)
         })
+    }
+
+    /**
+     * 调用 Typora 打开文件
+     */
+    openTypora(){
+        if (this.typoraPath){
+            var filePath = resolve() + "\\" + name
+            execFile(this.typoraPath, [filePath], function(err, data) {
+                if (err) {
+                    throw err;
+                }
+                console.log(data.toString());
+            });
+        } else {
+            console.log("Typora 模块未加载！")
+        }
     }
 }
 

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -1,8 +1,17 @@
 import inquirer from "inquirer";
 import MarkdownModel from "../config/markdown.js";
 import MucFile from "./file.js";
+import Config from "../config/index.js";
+
+var markdownConfig = new Config().readDetailConfig('Commands', 'mmd')
 
 class Markdown {
+    constructor() {
+        this.authorDefault = markdownConfig.default.author
+        this.fileDefault = markdownConfig.default.filename
+        this.descDefault = markdownConfig.default.description
+    }
+
     /**
      * 创建新文件
      * @param name 文件名称
@@ -10,9 +19,14 @@ class Markdown {
     createNew(name) {
         var mucFile = new MucFile()
         inquirer.prompt([
-            {type: 'input', message: '请输入文件名称', name: 'title', default: name || 'README'},
-            {type: 'input', message: '请输入作者', name: 'author', default: '目棃'},
-            {type: 'input', message: '请输入描述', name: 'desc', default: name === 'README' ? '说明文档' : name}
+            {type: 'input', message: '请输入文件名称', name: 'title', default: name || this.fileDefault},
+            {type: 'input', message: '请输入作者', name: 'author', default: this.authorDefault},
+            {
+                type: 'input',
+                message: '请输入描述',
+                name: 'desc',
+                default: name === this.fileDefault ? this.descDefault : name
+            }
         ]).then(async answers => {
             var mdModel = new MarkdownModel(answers.author, answers.desc)
             var mdPath = answers.title + '.md'

--- a/utils/yaml.js
+++ b/utils/yaml.js
@@ -1,48 +1,48 @@
 import YAML from 'yamljs';
-import MucFile from "./file.js";
-import MucConfig from "../config.js";
+import MucFile from './file.js';
+import MucConfig from '../config.js';
 
 class MucYaml {
-    constructor() {
-        this.configPath = MucConfig.getPath() + '\\config_default\\config.yml'
-        this.mucFile = new MucFile()
-    }
+	constructor() {
+		this.configPath = MucConfig.getPath() + '\\config_default\\config.yml';
+		this.mucFile = new MucFile();
+	}
 
-    /**
-     * 读取 yaml 文件
-     * @param path 文件路径
-     * @return {*}
-     */
-    yamlRead(path) {
-        return YAML.load(path)
-    }
+	/**
+	 * 读取 yaml 文件
+	 * @param path 文件路径
+	 * @return {*}
+	 */
+	yamlRead(path) {
+		return YAML.load(path);
+	}
 
-    /**
-     * 读取具体配置
-     * @param data yaml 文件内容
-     * @param args 配置位置
-     * @return {*} 配置内容
-     */
-    yamlDetailRead(data, args) {
-        var yamlRead = data
-        args.forEach(value => {
-            yamlRead = yamlRead[value]
-        })
-        return yamlRead
-    }
+	/**
+	 * 读取具体配置
+	 * @param data yaml 文件内容
+	 * @param args 配置位置
+	 * @return {*} 配置内容
+	 */
+	yamlDetailRead(data, args) {
+		var yamlRead = data;
+		args.forEach(value => {
+			yamlRead = yamlRead[value];
+		});
+		return yamlRead;
+	}
 
-    /**
-     * 修改 yaml 文件某属性值 todo 待检验
-     * @param path yaml 文件路径
-     * @param args 要修改属性位置
-     * @param key  要修改属性名称
-     * @param val  要修改属性值
-     */
-    yamlChange(path, args, key, val) {
-        var yamlOri = this.yamlRead(path)
-        yamlOri[args][key] = val
-        this.mucFile.change(path, yamlOri)
-    }
+	/**
+	 * 修改 yaml 文件某属性值 todo 待检验
+	 * @param path yaml 文件路径
+	 * @param args 要修改属性位置
+	 * @param key  要修改属性名称
+	 * @param val  要修改属性值
+	 */
+	yamlChange(path, args, key, val) {
+		var yamlOri = this.yamlRead(path);
+		yamlOri[args][key] = val;
+		this.mucFile.change(path, yamlOri);
+	}
 }
 
-export default MucYaml
+export default MucYaml;

--- a/utils/yaml.js
+++ b/utils/yaml.js
@@ -7,14 +7,24 @@ class MucYaml{
         this.mucFile = new MucFile()
     }
 
+    /**
+     * 读取 yaml 文件
+     * @param path 文件路径
+     * @return {*}
+     */
     yamlRead(path){
         return YAML.load(path)
     }
 
+    /**
+     * 读取具体配置
+     * @param data yaml 文件内容
+     * @param args 配置位置
+     * @return {*} 配置内容
+     */
     yamlDetailRead(data, args){
         var yamlRead = data
         args.forEach(value => {
-            console.log(value)
             yamlRead = yamlRead[value]
         })
         return yamlRead

--- a/utils/yaml.js
+++ b/utils/yaml.js
@@ -1,9 +1,10 @@
 import YAML from 'yamljs';
 import MucFile from "./file.js";
+import MucConfig from "../config.js";
 
-class MucYaml{
+class MucYaml {
     constructor() {
-        this.configPath = './config_default/config.yml'
+        this.configPath = MucConfig.getPath() + '\\config_default\\config.yml'
         this.mucFile = new MucFile()
     }
 
@@ -12,7 +13,7 @@ class MucYaml{
      * @param path 文件路径
      * @return {*}
      */
-    yamlRead(path){
+    yamlRead(path) {
         return YAML.load(path)
     }
 
@@ -22,7 +23,7 @@ class MucYaml{
      * @param args 配置位置
      * @return {*} 配置内容
      */
-    yamlDetailRead(data, args){
+    yamlDetailRead(data, args) {
         var yamlRead = data
         args.forEach(value => {
             yamlRead = yamlRead[value]
@@ -37,7 +38,7 @@ class MucYaml{
      * @param key  要修改属性名称
      * @param val  要修改属性值
      */
-    yamlChange(path, args, key, val){
+    yamlChange(path, args, key, val) {
         var yamlOri = this.yamlRead(path)
         yamlOri[args][key] = val
         this.mucFile.change(path, yamlOri)


### PR DESCRIPTION
这个版本更新的相比前几个还是挺多的。

加了 `yaml` 配置文件，用来控制 command 模块的加载，不过目前不支持通过 CLI 修改，部分配置可以通过 CLI 查看。

增加的东西主要就三个：

+ `mmd typora`：调用本地 `typora` 进行一些操作
+ `eslint`：引入 ESLint ，用于代码格式化
+ `ISSue_TEMPLATE`：抄的某项目 ISSUE 模板

剩下的要做的，目前确定的有两点：

+ `muc mmd` 后面可以加文件路径，如 `dir/file` 这样的，支持新建文件
+ `config.yml` 可以通过 CLI 对里面的内容进行修改