### PR TITLE
v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 Date: 2022-09-29
-Update: 2022-11-13
+Update: 2022-12-02
 Author: 目棃
 Description: 说明文档
 ---
@@ -43,6 +43,7 @@ Commands:
   set [options]   change subcommand use status
   mmd [options]   A SubCommand within MuCli for Markdown
   ncm [options]   A SubCommand within MuCli for SubCommand
+  pip [options]   A SubCommand within MuCli for pip
   help [command]  display help for command
 ```
 
@@ -51,6 +52,7 @@ Commands:
 + `set`：用于子命令的启用/禁用
 + `mmd`：用于 Markdown 相关操作
 + `ncm`：用于创建子命令 `Just for dev`
++ `pip`：用于 pip 相关操作
 
 ### 查看版本
 
@@ -58,7 +60,7 @@ Commands:
 
 ```text
 > muc -v
-0.4.2
+0.5.1
 ```
 
 子命令则通过 `-sv` 即 `subversion` 来查看，如下:
@@ -68,6 +70,8 @@ Commands:
 0.3.2
 > muc ncm -sv
 0.0.3
+> muc pip -sv
+0.1.0
 ```
 
 ### SubCli-Markdown
@@ -138,6 +142,33 @@ Commands:
 ```
 
 用于个人新建一个子命令，即 `Just for dev`。
+
+---
+
+## SubCli-pip
+
+对应的是上面的 `pip` 命令：
+
+```text
+> muc pip -h
+Usage: muc pip [options] [command]
+
+A SubCommand within MuCli for pip
+
+Options:
+  -sv                output the version number
+  -h, --help         display help for command
+
+Commands:
+  install [options]  install package
+  test               test mirror
+  show               show mirror
+  help [command]     display help for command
+```
+
+目前支持镜像源的可用性测试，以及镜像源的查看。
+
+`pip` 命令的 `pip install -i`跟 `pip install -r` 也支持使用镜像源。
 
 ---
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -24,15 +24,13 @@ MuCli.command('set')
 	.action(args => {
 		if (args.name && args.target) {
 			muc.transConfig(args.name, args.target);
-			muc.setConfig(MuCli, markdown, subCommand, template);
+			muc.setConfig(MuCli, markdown, subCommand, template, pip);
 		} else if (args.name) {
 			muc.transConfig(args.name, 'on');
-			muc.setConfig(MuCli, markdown, subCommand, template);
+			muc.setConfig(MuCli, markdown, subCommand, template, pip);
 		} else {
 			console.log('Please input a name.');
 		}
 	});
-
-MuCli.addCommand(pip);
 
 export default MuCli;

--- a/cli/pip.js
+++ b/cli/pip.js
@@ -1,43 +1,38 @@
 // Node JS
-import { Command } from "commander";
+import { Command } from 'commander';
 // MuCli JS
-import Pip from "../utils/pip.js";
-import { exec } from 'child_process';
+import Pip from '../utils/pip.js';
 
-const pip= new Command();
+const pip = new Command();
 
 // Base info
-pip
-    .name('pip')
-    .description('A SubCommand within MuCli for pip')
-    .version('0.0.1', '-sv')
+pip.name('pip')
+	.description('A SubCommand within MuCli for pip')
+	.version('0.1.0', '-sv');
 
-pip
-	.command('install')
+// 安装包
+pip.command('install')
 	.description('install package')
-	// 无参数接受后面的内容
 	.option('-p, --package [package]', 'install package')
 	.option('-r, --requirement [requirement]', 'install requirement')
 	.action(args => {
-		let sh_str = 'pip install -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com'
-		if(args.package){
-			exec(sh_str + ' ' + args.package, (error, stdout, stderr) => {
-				if (error) {
-					console.error(`执行的错误: ${error}`);
-					return;
-				}
-				console.log(`stdout: ${stdout}`);
-				console.log(`stderr: ${stderr}`);
-			});
-		}else if(args.requirement){
-			exec(sh_str + ' -r ' + args.requirement, (error, stdout, stderr) => {
-				if (error) {
-					console.error(`执行的错误: ${error}`);
-					return;
-				}
-				console.log(`stdout: ${stdout}`);
-				console.log(`stderr: ${stderr}`);
-			});
-		}
+		let pip = new Pip();
+		pip.install(args);
+	});
+
+// 测试镜像源
+pip.command('test')
+	.description('test mirror')
+	.action(async () => {
+		let pip = new Pip();
+		await pip.verifyMirror();
+	});
+
+// 查看镜像源
+pip.command('show')
+	.description('show mirror')
+	.action(() => {
+		let pip = new Pip();
+		pip.showMirror();
 	});
 export default pip;

--- a/config/index.js
+++ b/config/index.js
@@ -57,25 +57,56 @@ class Config {
 	}
 
 	/**
-	 * 修改配置文件
+	 * 修改命令可用性
 	 * @param name
 	 * @param target
 	 */
 	transConfig(name, target) {
 		let commandPath = this.mucYaml.configPath;
-		let commandList = ['all', 'mmd', 'tpl', 'ncm'];
+		let commandList = ['all', 'mmd', 'tpl', 'ncm', 'pip'];
 		let targetList = ['on', 'off'];
 		if (targetList.includes(target) && commandList.includes(name)) {
 			if (name === 'all') {
-				this.mucYaml.yamlChangeAsync(commandPath, 'mmd', 'enable', target === 'on');
-				this.mucYaml.yamlChangeAsync(commandPath, 'tpl', 'enable', target === 'on');
-				this.mucYaml.yamlChangeAsync(commandPath, 'ncm', 'enable', target === 'on');
+				this.mucYaml.yamlChangeAsync(
+					commandPath,
+					'mmd',
+					'enable',
+					target === 'on'
+				);
+				this.mucYaml.yamlChangeAsync(
+					commandPath,
+					'tpl',
+					'enable',
+					target === 'on'
+				);
+				this.mucYaml.yamlChangeAsync(
+					commandPath,
+					'ncm',
+					'enable',
+					target === 'on'
+				);
 			} else {
-				this.mucYaml.yamlChangeAsync(commandPath, name, 'enable', target==='on');
+				this.mucYaml.yamlChangeAsync(
+					commandPath,
+					name,
+					'enable',
+					target === 'on'
+				);
 			}
 		} else {
 			console.log('参数错误');
 		}
+	}
+
+	/**
+	 * 修改配置文件
+	 * @param name 命令
+	 * @param target 目标
+	 * @param value 值
+	 */
+	changeConfig(name, target, value) {
+		let commandPath = this.mucYaml.configPath;
+		this.mucYaml.yamlChangeAsync(commandPath, name, target, value);
 	}
 }
 

--- a/config/pip.js
+++ b/config/pip.js
@@ -1,5 +1,101 @@
-class PipModel {
+import axios from 'axios';
 
+/**
+ * 镜像模型
+ */
+export class MirrorModel {
+	/**
+	 * 构造函数
+	 * @param mirror 镜像
+	 */
+	constructor(mirror) {
+		this.name = mirror.name;
+		this.url = mirror.url;
+		if (mirror.usable === true || mirror.usable === false) {
+			this.usable = mirror.usable;
+		} else {
+			// 默认不可用
+			this.usable = false;
+		}
+	}
+
+	/**
+	 * 获取镜像模型
+	 */
+	getModel() {
+		return {
+			name: this.name,
+			url: this.url,
+			usable: this.usable,
+		};
+	}
+
+	/**
+	 * 测试镜像地址是否可用
+	 */
+	async verifyMirror(url = undefined) {
+		if (url === undefined) {
+			url = this.url;
+		}
+		return await axios
+			.get(url)
+			.then(response => {
+				return response.status === 200;
+			})
+			.catch(error => {
+				console.log(error);
+				return false;
+			});
+	}
+
+	/**
+	 * 获取镜像地址
+	 */
+	getMirrorUrl() {
+		return this.url;
+	}
+
+	/**
+	 * 获取镜像名称
+	 */
+	getMirrorName() {
+		return this.name;
+	}
+
+	/**
+	 * 更新镜像地址
+	 */
+	updateMirrorUrl(url) {
+		this.url = url;
+	}
+
+	/**
+	 * 输出镜像信息
+	 */
+	outputMirrorInfo() {
+		console.log(
+			// 左对齐
+			`镜像名称：${this.name}，镜像地址：${this.url}，是否可用：${this.usable}`
+		);
+	}
 }
 
-export default PipModel;
+export class PipModel {
+	constructor(useMirror, mirrorList) {
+		// 镜像源是否采用
+		this.useMirror = useMirror;
+		// 镜像源地址
+		// {name: '清华', url: 'https://pypi.tuna.tsinghua.edu.cn/simple'}
+		this.mirrorList = mirrorList;
+	}
+
+	/**
+	 * 获取所有镜像源信息
+	 * @return {Array<MirrorModel>} 镜像源信息
+	 */
+	getMirrorList() {
+		this.mirrorList.forEach(mirror => {
+			mirror.outputMirrorInfo();
+		});
+	}
+}

--- a/config_default/config.yml
+++ b/config_default/config.yml
@@ -15,3 +15,16 @@ Commands:
     ncm:
         enable: true
         name: subCommand
+    pip:
+        enable: true
+        name: pip
+        mirrorList:
+            - {name: tsinghua, url: 'https://pypi.tuna.tsinghua.edu.cn/simple', usable: true}
+            - {name: aliyun, url: 'https://mirrors.aliyun.com/pypi/simple/', usable: true}
+            - {name: douban, url: 'http://pypi.douban.com/simple/', usable: true}
+            - {name: 163, url: 'http://mirrors.163.com/pypi/simple/', usable: true}
+            - {name: 中国科技大学, url: 'http://pypi.mirrors.ustc.edu.cn/simple/', usable: true}
+            - {name: 南京大学, url: 'http://mirrors.nju.edu.cn/pypi/web/simple/', usable: true}
+            - {name: 清华大学, url: 'https://pypi.tuna.tsinghua.edu.cn/simple/', usable: true}
+            - {name: 中国科学技术大学, url: 'http://pypi.mirrors.ustc.edu.cn/simple/', usable: true}
+            - {name: 山东理工大学, url: 'http://pypi.sdutlinux.org/', usable: true}

--- a/config_default/config.yml
+++ b/config_default/config.yml
@@ -19,12 +19,11 @@ Commands:
         enable: true
         name: pip
         mirrorList:
-            - {name: tsinghua, url: 'https://pypi.tuna.tsinghua.edu.cn/simple', usable: true}
             - {name: aliyun, url: 'https://mirrors.aliyun.com/pypi/simple/', usable: true}
+            - {name: 清华大学, url: 'https://pypi.tuna.tsinghua.edu.cn/simple/', usable: true}
             - {name: douban, url: 'http://pypi.douban.com/simple/', usable: true}
             - {name: 163, url: 'http://mirrors.163.com/pypi/simple/', usable: true}
             - {name: 中国科技大学, url: 'http://pypi.mirrors.ustc.edu.cn/simple/', usable: true}
             - {name: 南京大学, url: 'http://mirrors.nju.edu.cn/pypi/web/simple/', usable: true}
-            - {name: 清华大学, url: 'https://pypi.tuna.tsinghua.edu.cn/simple/', usable: true}
             - {name: 中国科学技术大学, url: 'http://pypi.mirrors.ustc.edu.cn/simple/', usable: true}
             - {name: 山东理工大学, url: 'http://pypi.sdutlinux.org/', usable: true}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import Config from './config/index.js';
 import markdown from './cli/markdown.js';
 import subCommand from './cli/SubCommand.js';
 import template from './cli/template.js';
+import pip from './cli/pip.js';
 
 // Read command line arguments
 const cmd = process.argv;
@@ -14,7 +15,7 @@ const cmd = process.argv;
 const muc = new Config();
 
 // Load subCommand and setting
-muc.setConfig(MuCli, markdown, subCommand, template);
+muc.setConfig(MuCli, markdown, subCommand, template, pip);
 
 // Parse command line arguments
 MuCli.parse(cmd);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@btmuli/mucli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@btmuli/mucli",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
+        "axios": "^1.2.0",
         "commander": "^9.4.0",
         "inquirer": "^9.1.2",
         "silly-datetime": "^0.1.2",
@@ -235,6 +236,21 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.2.0.tgz",
+      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -390,6 +406,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
@@ -449,6 +476,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/doctrine": {
@@ -832,6 +867,32 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1184,6 +1245,25 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -1428,6 +1508,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -2086,6 +2171,21 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.2.0.tgz",
+      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2183,6 +2283,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
@@ -2226,6 +2334,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -2510,6 +2623,21 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2756,6 +2884,19 @@
         }
       }
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -2921,6 +3062,11 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/BTMuli/MuCli#readme",
   "dependencies": {
+    "axios": "^1.2.0",
     "commander": "^9.4.0",
     "inquirer": "^9.1.2",
     "silly-datetime": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btmuli/mucli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "个人用的 Node Cli",
   "type": "module",
   "main": "index.js",

--- a/utils/pip.js
+++ b/utils/pip.js
@@ -55,42 +55,32 @@ class Pip {
 	 * @param args
 	 */
 	install(args) {
-		// 根据镜像源url获取host
+		// 根据镜像源url获取host --trusted-host
 		var host = this.mirrorList.useMirror.url
-			.replace('https://', '')
-			.replace('http://', '');
 		var command = 'pip install -i ' + host + ' ';
 		if (args.package !== undefined) {
 			command += args.package;
 			console.log('command:\t' + command);
-			exec(command + args.package, (error, stdout, stderr) => {
+			// 在命令运行的目录下执行命令
+			exec(command, { cwd: process.cwd() }, (error, stdout, stderr) => {
 				if (error) {
-					console.log(`error: ${error.message}`);
-					return;
-				}
-				if (stderr) {
-					console.log(`stderr: ${stderr}`);
+					console.error(`执行的错误: ${error}`);
 					return;
 				}
 				console.log(`stdout: ${stdout}`);
+				console.log(`stderr: ${stderr}`);
 			});
 		} else if (args.requirement !== undefined) {
 			command += '-r ' + args.requirement;
-			console.log('command:' + command);
-			exec(
-				command + '-r ' + args.requirement,
-				(error, stdout, stderr) => {
-					if (error) {
-						console.log(`error: ${error.message}`);
-						return;
-					}
-					if (stderr) {
-						console.log(`stderr: ${stderr}`);
-						return;
-					}
-					console.log(`stdout: ${stdout}`);
+			console.log('command:\t' + command);
+			exec(command, { cwd: process.cwd() }, (error, stdout, stderr) => {
+				if (error) {
+					console.error(`执行的错误: ${error}`);
+					return;
 				}
-			);
+				console.log(`stdout: ${stdout}`);
+				console.log(`stderr: ${stderr}`);
+			});
 		}
 	}
 

--- a/utils/pip.js
+++ b/utils/pip.js
@@ -1,11 +1,107 @@
 //Node JS
-import inquirer from "inquirer";
+import { exec } from 'child_process';
 // MuCli JS
-import PipModel from "../config/pip.js";
-import MucFile from "./file.js";
+import { PipModel, MirrorModel } from '../config/pip.js';
+import Config from '../config/index.js';
 
 class Pip {
+	/**
+	 * 初始化构建各种设置
+	 */
+	constructor() {
+		var pipConfig = new Config().readDetailConfig('Commands', 'pip');
+		this.pipConfig = new Config();
+		var mirrorList = [];
+		var mirrorUse = undefined;
+		for (var i = 0; i < pipConfig.mirrorList.length; i++) {
+			var mirror = new MirrorModel(pipConfig.mirrorList[i]);
+			if (mirror.usable === true && mirrorUse === undefined) {
+				mirrorUse = mirror;
+			}
+			mirrorList.push(mirror);
+		}
+		if (mirrorUse === undefined) {
+			mirrorUse = this.mirrorList[0];
+		}
+		this.mirrorList = new PipModel(mirrorUse, mirrorList);
+	}
 
+	/**
+	 * 测试镜像源
+	 */
+	async verifyMirror() {
+		let mirrorListTest = this.mirrorList.mirrorList;
+		console.log('正在测试镜像源,请稍后...');
+		for (var i = 0; i < mirrorListTest.length; i++) {
+			var mirror = mirrorListTest[i];
+			console.log('正在测试镜像源:' + mirror.name);
+			var result = await mirror.verifyMirror();
+			console.log('测试结果:' + result);
+			mirrorListTest[i].usable = result;
+		}
+		// 将测试结果写入配置文件
+		this.mirrorList.mirrorList = mirrorListTest;
+		console.log('正在写入配置文件...');
+		this.pipConfig.changeConfig(
+			'pip',
+			'mirrorList',
+			this.mirrorList.mirrorList
+		);
+		console.log('写入配置文件成功');
+	}
+
+	/**
+	 * 安装包
+	 * @param args
+	 */
+	install(args) {
+		// 根据镜像源url获取host
+		var host = this.mirrorList.useMirror.url
+			.replace('https://', '')
+			.replace('http://', '');
+		var command = 'pip install -i ' + host + ' ';
+		if (args.package !== undefined) {
+			command += args.package;
+			console.log('command:\t' + command);
+			exec(command + args.package, (error, stdout, stderr) => {
+				if (error) {
+					console.log(`error: ${error.message}`);
+					return;
+				}
+				if (stderr) {
+					console.log(`stderr: ${stderr}`);
+					return;
+				}
+				console.log(`stdout: ${stdout}`);
+			});
+		} else if (args.requirement !== undefined) {
+			command += '-r ' + args.requirement;
+			console.log('command:' + command);
+			exec(
+				command + '-r ' + args.requirement,
+				(error, stdout, stderr) => {
+					if (error) {
+						console.log(`error: ${error.message}`);
+						return;
+					}
+					if (stderr) {
+						console.log(`stderr: ${stderr}`);
+						return;
+					}
+					console.log(`stdout: ${stdout}`);
+				}
+			);
+		}
+	}
+
+	/**
+	 * 查看镜像源
+	 */
+	showMirror() {
+		console.log('当前使用镜像源:' + this.mirrorList.useMirror.name);
+		console.log('镜像源列表:');
+		this.mirrorList.getMirrorList();
+	}
 }
 
 export default Pip;

--- a/utils/yaml.js
+++ b/utils/yaml.js
@@ -47,7 +47,7 @@ class MucYaml {
 	 */
 	yamlChangeAsync(path, args, key, val) {
 		var yamlTrans = this.yamlRead(path);
-		yamlTrans["Commands"][args][key] = val;
+		yamlTrans['Commands'][args][key] = val;
 		this.mucFile.changeAsync(path, YAML.stringify(yamlTrans, 4));
 	}
 }


### PR DESCRIPTION
5.0只是简单的写了个`exec`，5.1跟其他配置统一了文件跟方法，目前支持：

+ 镜像源测试，将测试结果写回配置文件，并将第一个为 true 的设为使用镜像源
+ 镜像源查看，查看当前所有镜像源跟是否可用
+ 通过镜像源下载，支持`-i`跟`-r`，如`muc pip install -i`跟`muc pip install -r`

后续考虑加入镜像源的增删，当前使用镜像的更换，不过目前排第一的是阿里镜像，应该够用了...