### PR TITLE
v0.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Update: 2022-12-21
 > 
 > 更新于 `2022-12-21 12:58:15`
 
-![](https://img.shields.io/github/license/BTMuli/MuCli?style=for-the-badge)![](https://img.shields.io/github/workflow/status/btmuli/MuCli/MuCli%20Workflow?style=for-the-badge)![](https://img.shields.io/github/package-json/v/btmuli/mucli?style=for-the-badge)![](https://img.shields.io/github/last-commit/btmuli/mucli?style=for-the-badge)
+![](https://img.shields.io/github/license/BTMuli/MuCli?style=for-the-badge)![](https://img.shields.io/github/package-json/v/btmuli/mucli?style=for-the-badge)![](https://img.shields.io/github/last-commit/btmuli/mucli?style=for-the-badge)
 
 ## 前言
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 Author: 目棃
 Date: 2022-09-29
 Description: 说明文档
-Update: 2022-12-21
+Update: 2023-02-13
 ---
 
 > 本文档 [`Front-matter`](https://github.com/BTMuli/Mucli#FrontMatter) 由 [MuCli](https://github.com/BTMuli/Mucli) 自动生成于`2022-12-21 12:58:15`
 > 
-> 更新于 `2022-12-21 12:58:15`
+> 更新于 `2023-02-13 15:54:40`
 
 ![](https://img.shields.io/github/license/BTMuli/MuCli?style=for-the-badge)![](https://img.shields.io/github/package-json/v/btmuli/mucli?style=for-the-badge)![](https://img.shields.io/github/last-commit/btmuli/mucli?style=for-the-badge)
 
@@ -64,16 +64,16 @@ Commands:
 
 ```text
 > muc -v
-0.6.2
+0.6.3
 ```
 
 子命令则通过 `-sv` 即 `subversion` 来查看，如下:
 
 ```text
 > muc dev -sv
-0.1.8
+0.1.9
 > muc mmd -sv
-0.6.0
+0.6.2
 > muc pip -sv
 0.3.0
 ```
@@ -85,9 +85,9 @@ Commands:
 ┌─────────┬─────────┬────────┬────────────────────────────────────────────┐
 │ (index) │ version │ enable │                description                 │
 ├─────────┼─────────┼────────┼────────────────────────────────────────────┤
-│   muc   │ '0.6.2' │  true  │  'A Node Cli for Personal Use by BTMUli.'  │
-│   dev   │ '0.1.8' │  true  │ 'A SubCommand within MuCli for SubCommand' │
-│   mmd   │ '0.6.0' │  true  │  'A SubCommand within MuCli for Markdown'  │
+│   muc   │ '0.6.3' │  true  │  'A Node Cli for Personal Use by BTMUli.'  │
+│   dev   │ '0.1.9' │  true  │ 'A SubCommand within MuCli for SubCommand' │
+│   mmd   │ '0.6.2' │  true  │  'A SubCommand within MuCli for Markdown'  │
 │   pip   │ '0.3.0' │  true  │    'A SubCommand within MuCli for pip'     │
 └─────────┴─────────┴────────┴────────────────────────────────────────────┘
 ```

--- a/cli/markdown.js
+++ b/cli/markdown.js
@@ -2,7 +2,7 @@
  * @author: BTMuli<bt-muli@outlook.com>
  * @date: 2022-12-06
  * @description: 子命令，负责处理 markdown 文件
- * @update: 2021-12-21
+ * @update: 2023-02-13
  */
 
 /* Node */
@@ -39,7 +39,7 @@ markdown
 /* 更新 markdown 文件头信息 */
 markdown
 	.command('update')
-	.option('-n, --name <name>', 'the name of the markdown file', 'README')
+	.option('-n, --name <name>', 'the name of the markdown file', 'README.md')
 	.description('update the header of the markdown file')
 	.action(async options => {
 		let md = new Markdown();

--- a/config/markdown.js
+++ b/config/markdown.js
@@ -2,7 +2,7 @@
  * @author: BTMuli<bt-muli@outlook.com>
  * @date: 2022-12-06
  * @description: 子命令 mmd 相关模型
- * @update: 2021-12-21
+ * @update: 2023-02-13
  */
 
 /* Node */
@@ -58,18 +58,26 @@ class MarkdownModel {
 	 */
 	async readHeader(fileName) {
 		const headContent = await new MucFile().readLine(fileName, 10);
-		return {
-			header: {
-				author: headContent[1].split(':')[1].trim(),
-				date: headContent[2].split(':')[1].trim(),
-				description: headContent[3].split(':')[1].trim(),
-				update: headContent[4].split(':')[1].trim(),
-			},
+		// 不确定 author date description update 顺序
+		const header = {
+			header: {},
 			quote: {
 				date: headContent[7].split('`')[3],
 				update: headContent[9].split('`')[1],
 			}
 		};
+		headContent.forEach((item) => {
+			if (item.includes('Author:')) {
+				header.header.author = item.split('Author: ')[1];
+			} else if (item.includes('Date:')) {
+				header.header.date = item.split('Date: ')[1];
+			} else if (item.includes('Description:')) {
+				header.header.description = item.split('Description: ')[1];
+			} else if (item.includes('Update:')) {
+				header.header.update = item.split('Update: ')[1];
+			}
+		});
+		return header;
 	}
 	/**
 	 * @description 更新文件FrontMatter
@@ -103,7 +111,7 @@ class MarkdownModel {
 			this.sign + this.lineBreak +
 			'Author: ' + labelUpdate.header.author + this.lineBreak +
             'Date: ' + labelUpdate.header.date + this.lineBreak +
-            'Description: ' + this.description + this.lineBreak +
+            'Description: ' + labelUpdate.header.description + this.lineBreak +
 			'Update: ' + labelUpdate.header.update + this.lineBreak +
             this.sign + this.lineBreak + this.lineBreak +
             this.quote + '`' + labelUpdate.quote.date + '`' + this.lineBreak +

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@btmuli/mucli",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@btmuli/mucli",
-            "version": "0.6.2",
+            "version": "0.6.3",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@btmuli/mucli",
     "version": "0.6.2",
     "subversion": {
-        "dev": "0.1.8",
+        "dev": "0.1.9",
         "mmd": "0.6.1",
         "pip": "0.3.0"
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.6.2",
     "subversion": {
         "dev": "0.1.8",
-        "mmd": "0.6.0",
+        "mmd": "0.6.1",
         "pip": "0.3.0"
     },
     "description": "个人用的 Node Cli",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.6.2",
     "subversion": {
         "dev": "0.1.9",
-        "mmd": "0.6.1",
+        "mmd": "0.6.2",
         "pip": "0.3.0"
     },
     "description": "个人用的 Node Cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@btmuli/mucli",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "subversion": {
         "dev": "0.1.9",
         "mmd": "0.6.2",

--- a/utils/dev.js
+++ b/utils/dev.js
@@ -2,11 +2,12 @@
  * @author: BTMuli<bt-muli@outlook.com>
  * @date: 2022-12-06
  * @description: 子命令 dev 的具体实现
- * @update: 2022-12-15
+ * @update: 2023-02-13
  */
 
 /* Node */
 import inquirer from 'inquirer';
+import { exec } from 'child_process';
 /* MuCli */
 import MucFile from './file.js';
 import DevModel from '../config/dev.js';
@@ -182,7 +183,32 @@ class Dev {
 		this.updatePackage('all', upVersion);
 		if (upVersion !== oldVersion) {
 			console.log(`\n版本号已更新 ${oldVersion} -> ${upVersion}`);
-			console.log('请运行 npm install 更新依赖\n');
+			inquirer
+				.prompt([
+					{
+						type: 'confirm',
+						name: 'install',
+						message: '是否运行 npm install 更新依赖？',
+						default: true,
+					},
+				])
+				.then(answers => {
+					if (answers.install) {
+						exec('npm install', async (err, stdout, stderr) => {
+							if (err) {
+								console.log(err);
+								return;
+							}
+							if (stderr) {
+								console.log(stderr);
+								return;
+							}
+							console.log(stdout);
+						});
+					} else {
+						console.log('\n请运行 npm install 更新依赖\n');
+					}
+				});
 		} else {
 			console.log(`\n版本号未更新，当前 MuCli 版本为 ${oldVersion}\n`);
 		}

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -238,6 +238,11 @@ class Markdown {
 	 * @param fileName {string} 文件名称
 	 */
 	async promoteUpdateFile(fileName) {
+		// 检测后缀
+		if (!fileName.endsWith('.md')) {
+			console.log('文件名不合法');
+			return;
+		}
 		const fileCheck = await this.mucFile.fileExist(fileName);
 		if (fileCheck) {
 			const hasHeader = await this.checkHeader(fileName);

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -2,7 +2,7 @@
  * @author: BTMuli<bt-muli@outlook.com>
  * @date: 2022-12-06
  * @description: markdown 文件相关操作
- * @update: 2022-12-21
+ * @update: 2023-02-13
  */
 
 /* Node */
@@ -170,9 +170,18 @@ class Markdown {
 	/* File 相关 */
 	/**
 	 * @description 创建新文件前的提示
-	 * @param fileName {string} 文件名称
+	 * @param filePath {string} 文件路径
 	 */
-	promoteCreateFile(fileName) {
+	promoteCreateFile(filePath) {
+		let fileName = filePath.split('/').pop();
+		if (fileName.includes('.')) {
+			if(fileName.endsWith('.md')) {
+				fileName = fileName.replace(/\.md$/, '');
+			} else {
+				console.log('\n文件名不合法，文件名应以 .md 结尾');
+				return;
+			}
+		}
 		inquirer
 			.prompt([
 				{
@@ -201,7 +210,7 @@ class Markdown {
 						])
 						.then(async lv2 => {
 							await this.createFile(
-								lv1.title,
+								filePath,
 								lv2.author,
 								lv2.description
 							);
@@ -225,7 +234,7 @@ class Markdown {
 						])
 						.then(async lv3 => {
 							await this.createFile(
-								lv1.title,
+								filePath,
 								lv3.author,
 								lv3.description
 							);


### PR DESCRIPTION
```text
muc 0.6.2 -> 0.6.3
dev 0.1.8 -> 0.1.9
mmd 0.6.0 -> 0.6.2
```

README 去除了 workflow 徽标，手动跑就不贴这个标记了

mmd update 的 header 内容修正，不会再清除 desc 了，顺带读 frontMatter 不卡排序了，但是更新还是卡的

dev 优化了一下，更新主版本会跑 npm i 来更新 package-lock ，子命令则不会因为子命令版本没在文件里面

