### PR TITLE
v0.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 Author: 目棃
 Date: 2022-09-29
 Description: 说明文档
-Update: 2023-02-13
+Update: 2023-02-15
 ---
 
 > 本文档 [`Front-matter`](https://github.com/BTMuli/Mucli#FrontMatter) 由 [MuCli](https://github.com/BTMuli/Mucli) 自动生成于`2022-12-21 12:58:15`
 > 
-> 更新于 `2023-02-13 15:54:40`
+> 更新于 `2023-02-15 14:58:43`
 
 ![](https://img.shields.io/github/license/BTMuli/MuCli?style=for-the-badge)![](https://img.shields.io/github/package-json/v/btmuli/mucli?style=for-the-badge)![](https://img.shields.io/github/last-commit/btmuli/mucli?style=for-the-badge)
 
@@ -45,6 +45,7 @@ Options:
 
 Commands:
   set [options]  change subcommand use status
+  update         update muc from upstream
   dev [options]  A SubCommand within MuCli for SubCommand
   mmd [options]  A SubCommand within MuCli for Markdown
   pip [options]  A SubCommand within MuCli for pip
@@ -53,6 +54,7 @@ Commands:
 如上，除了 Commander 默认的 `help` 之外，目前的子命令如下：
 
 + `set`：用于子命令的启用/禁用
++ `update`：用于检测上游版本更新
 + `list`：用于列出所有子命令
 + `mmd`：用于 Markdown 相关操作
 + `dev`：用于创建子命令及更新命令版本，**Just for Dev**。
@@ -64,7 +66,7 @@ Commands:
 
 ```text
 > muc -v
-0.6.3
+0.6.4
 ```
 
 子命令则通过 `-sv` 即 `subversion` 来查看，如下:
@@ -85,7 +87,7 @@ Commands:
 ┌─────────┬─────────┬────────┬────────────────────────────────────────────┐
 │ (index) │ version │ enable │                description                 │
 ├─────────┼─────────┼────────┼────────────────────────────────────────────┤
-│   muc   │ '0.6.3' │  true  │  'A Node Cli for Personal Use by BTMUli.'  │
+│   muc   │ '0.6.4' │  true  │  'A Node Cli for Personal Use by BTMUli.'  │
 │   dev   │ '0.1.9' │  true  │ 'A SubCommand within MuCli for SubCommand' │
 │   mmd   │ '0.6.2' │  true  │  'A SubCommand within MuCli for Markdown'  │
 │   pip   │ '0.3.0' │  true  │    'A SubCommand within MuCli for pip'     │
@@ -265,7 +267,7 @@ Options:
 Author: 目棃
 Date: 2022-09-29
 Description: 说明文档
-Update: 2022-12-21
+Update: 2023-02-15
 ---
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@btmuli/mucli",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@btmuli/mucli",
-            "version": "0.6.3",
+            "version": "0.6.4",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@btmuli/mucli",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "subversion": {
         "dev": "0.1.9",
         "mmd": "0.6.2",

--- a/utils/markdown.js
+++ b/utils/markdown.js
@@ -175,7 +175,7 @@ class Markdown {
 	promoteCreateFile(filePath) {
 		let fileName = filePath.split('/').pop();
 		if (fileName.includes('.')) {
-			if(fileName.endsWith('.md')) {
+			if (fileName.endsWith('.md')) {
 				fileName = fileName.replace(/\.md$/, '');
 			} else {
 				console.log('\n文件名不合法，文件名应以 .md 结尾');


### PR DESCRIPTION
muc 0.6.3 -> 0.6.4

增加了一个 `update` 命令，用于检测上游（npm 仓库）最新版本，与本地版本比对更新。